### PR TITLE
edited toml file, tokio-rusqlite is now  bundled

### DIFF
--- a/rust_rewrite/Cargo.toml
+++ b/rust_rewrite/Cargo.toml
@@ -21,7 +21,8 @@ jsonwebtoken = "9" # JWT library
 serde = "1.0.217" # serialization library
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
 
-tokio-rusqlite = "0.6.0" # async SQLite
+# tokio-rusqlite = "0.6.0" # async SQLite
+tokio-rusqlite = { version = "0.6", features = ["bundled"] }
 serde_json = "1.0.138"
 password-worker = "0.4.0"
 


### PR DESCRIPTION
## Description

Had this error, when i tried to build locally:
note: LINK : fatal error LNK1181: cannot open input file 'sqlite3.lib'␍

Fixed it by editing toml to:
tokio-rusqlite = { version = "0.6", features = ["bundled"] }

so that rust compiles sqllite from source

Issue # 

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
