### PR TITLE
Change search to use query params in url

### DIFF
--- a/rust_rewrite/static/scripts/search.js
+++ b/rust_rewrite/static/scripts/search.js
@@ -31,7 +31,7 @@ function search() {
 
 async function makeSearchRequest() {
     const query = document.getElementById("search-input").value;
-    const response = await fetch(`/api/v1/search?q=${encodeURIComponent(query)}`); // This supposedly also needs a 'language' parameter, but I can't find it in the legacy code. Does it mean programming language or human language?
+    const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`); // This supposedly also needs a 'language' parameter, but I can't find it in the legacy code. Does it mean programming language or human language?
     const searchResults = await response.json();
     console.log(searchResults);
 

--- a/rust_rewrite/static/scripts/search.js
+++ b/rust_rewrite/static/scripts/search.js
@@ -16,6 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // searchButton.addEventListener('click', makeSearchRequest);
 });
 
+function search() {
+    const query = document.getElementById("search-input").value;
+    if (query) {
+      window.location.href = `/?q=${encodeURIComponent(query)}`;
+    }
+}
+
 async function makeSearchRequest() {
     const query = document.getElementById("search-input").value;
     const response = await fetch(`/api/v1/search?q=${encodeURIComponent(query)}`); // This supposedly also needs a 'language' parameter, but I can't find it in the legacy code. Does it mean programming language or human language?

--- a/rust_rewrite/static/scripts/search.js
+++ b/rust_rewrite/static/scripts/search.js
@@ -8,9 +8,15 @@ document.addEventListener('DOMContentLoaded', () => {
     // Search when the user presses Enter.
     searchInput.addEventListener('keypress', (event) => {
         if (event.key === 'Enter') {
-            makeSearchRequest();
+            search();
         }
     });
+
+    const params = new URLSearchParams(window.location.search);
+    const value = params.get('q'); // Get a specific query param
+    if(value) {
+        makeSearchRequest();
+    }
 
     // Search when the user clicks the search button.
     // searchButton.addEventListener('click', makeSearchRequest);

--- a/rust_rewrite/static/search.html
+++ b/rust_rewrite/static/search.html
@@ -16,7 +16,7 @@
          <!-- I figure it's a lot easier to use that and populate the search results with JavaScript. -->
 
         <input id="search-input" placeholder="Search..." />
-        <button onclick="makeSearchRequest()">Search</button>
+        <button onclick="search()">Search</button>
     </div>
 
     <div id="results"></div>


### PR DESCRIPTION
## Description

made it so clicking the search button, or pressing enter, now uses the search() function, which will redirect to /?q=searc_input
added script that detects if the query param q is sat, if it is we then run makeSearchRequest.

This will make links shareable, and follows the behavior from legacy.

Issue #49 

## Type of change
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
