### PR TITLE
added healthcheck back

### DIFF
--- a/rust_rewrite/docker-compose.yml
+++ b/rust_rewrite/docker-compose.yml
@@ -48,6 +48,11 @@ services:
     restart: unless-stopped
     networks:
       - sauron-network
+    healthcheck:
+       test: ["CMD-SHELL", "pg_isready -U sauron"]
+       interval: 5s
+       timeout: 5s
+       retries: 5
 
   #grafana:
     #image: grafana/grafana:latest


### PR DESCRIPTION
This pull request introduces a health check to the `services` section of the `rust_rewrite/docker-compose.yml` file, ensuring the PostgreSQL service is operational before proceeding.

* [`rust_rewrite/docker-compose.yml`](diffhunk://#diff-87518ca07f492a62cf905b742c6fae6d7e43b20deb7fd6f108a75c789cddba26R51-R55): Added a `healthcheck` configuration for the PostgreSQL service. The health check uses the `pg_isready` command to verify database readiness, with a 5-second interval, 5-second timeout, and up to 5 retries.